### PR TITLE
Check days as well as seconds when seeing if a model is locked.

### DIFF
--- a/locking/models.py
+++ b/locking/models.py
@@ -71,7 +71,8 @@ class LockableModel(models.Model):
         Works by calculating if the last lock (self.locked_at) has timed out or not.
         """
         if isinstance(self.locked_at, datetime):
-            if (datetime.today() - self.locked_at).seconds < LOCK_TIMEOUT:
+            timedelta_since_lock = datetime.today() - self.locked_at
+            if timedelta_since_lock.days == 0 and timedelta_since_lock.seconds < LOCK_TIMEOUT:
                 return True
             else:
                 return False

--- a/locking/models.py
+++ b/locking/models.py
@@ -72,7 +72,7 @@ class LockableModel(models.Model):
         """
         if isinstance(self.locked_at, datetime):
             timedelta_since_lock = datetime.today() - self.locked_at
-            if timedelta_since_lock.days == 0 and timedelta_since_lock.seconds < LOCK_TIMEOUT:
+            if timedelta_since_lock.total_seconds() < LOCK_TIMEOUT:
                 return True
             else:
                 return False


### PR DESCRIPTION
ping @ldko, @madhulika95b, this is to fix an issue where unlocked models get relocked for the same time period each day since we aren't checking the elapsed days. So if you have a lock duration of 1 hour and you lock a model at 3pm Tuesday, the lock will clear after 4pm Tuesday, but then come back Wednesday from 3pm to 4pm, and every day thereafter, because we're only checking the elapsed seconds, which gets rolled over into elapsed days after 24 hours. This fixes that.